### PR TITLE
Add benchmarks for filter, map and reduce

### DIFF
--- a/itertools_bench_test.go
+++ b/itertools_bench_test.go
@@ -1,0 +1,68 @@
+package itertools
+
+import "testing"
+
+func BenchmarkFilter(b *testing.B) {
+	pred := func(i interface{}) bool {
+		return i.(uint64)%2 == 1
+	}
+
+	for i := 0; i < b.N; i++ {
+		Filter(pred, Uint64(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+	}
+}
+
+func BenchmarkNoFilter(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		input := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+		results := make([]uint64, 0)
+
+		for _, n := range input {
+			if n%2 == 1 {
+				results = append(results, n)
+			}
+		}
+	}
+}
+
+func BenchmarkMap(b *testing.B) {
+	mapper := func(i interface{}) interface{} {
+		return len(i.(string))
+	}
+
+	for i := 0; i < b.N; i++ {
+		Map(mapper, New("a", "ab", "abc", "abcd"))
+	}
+}
+
+func BenchmarkNoMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		input := []string{"a", "ab", "abc", "abcd"}
+		results := make([]int, 0)
+
+		for _, w := range input {
+			results = append(results, len(w))
+		}
+	}
+}
+
+func BenchmarkReduce(b *testing.B) {
+	summer := func(memo interface{}, el interface{}) interface{} {
+		return memo.(float64) + el.(float64)
+	}
+
+	for i := 0; i < b.N; i++ {
+		Reduce(Float64(.1, .2, .3, .22), summer, float64(0))
+	}
+}
+
+func BenchmarkNoReduce(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		input := []float64{.1, .2, .3, .22}
+		result := 0.0
+
+		for _, n := range input {
+			result += n
+		}
+	}
+}


### PR DESCRIPTION
Running the included benchmarks with `go test -bench .` yields the following results on my machine:

```
BenchmarkFilter   200000         41188 ns/op
BenchmarkNoFilter    5000000           640 ns/op
BenchmarkMap       10000        108577 ns/op
BenchmarkNoMap  10000000           321 ns/op
BenchmarkReduce  1000000          1962 ns/op
BenchmarkNoReduce   100000000           22.0 ns/op
```

Which means: 

Filter: 64x slower
Map: 338x slower
Reduce: 89x slower

I like the convenience this package gives, but I think it should be transparent how much slower this approach is, in order to make the right decision.
